### PR TITLE
Monad Transformer instances

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,4 @@
+version                                      = "2.3.2"
 align.openParenCallSite                      = false
 align.tokens                                 = ["%", "%%", {code = "=>", owner = "Case"}, {code = "=", owner = "(Enumerator.Val|Defn.(Va(l|r)|Def|Type))"}, ]
 align.arrowEnumeratorGenerator               = true

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,8 @@ val commonSettings = Seq(
   libraryDependencies ++= Seq(
     Libraries.catsEffect,
     Libraries.scalaTest,
-    CompilerPlugins.bm4
+    CompilerPlugins.bm4,
+    CompilerPlugins.kindProjector
   ),
   resolvers += "Apache public" at "https://repository.apache.org/content/groups/public/",
   scalafmtOnCompile := true,

--- a/core/src/main/scala/cats/effect/Console.scala
+++ b/core/src/main/scala/cats/effect/Console.scala
@@ -16,8 +16,9 @@
 
 package cats.effect
 
+import cats._
+import cats.data._
 import cats.effect.transformed.TransformedConsole
-import cats.~>
 
 /**
   * Effect type agnostic `Console` with common methods to write and read from the standard console.
@@ -78,4 +79,29 @@ object Console {
   object implicits {
     implicit val ioConsole: Console[IO] = io
   }
+
+  // Monad Transformer instances
+
+  implicit def eitherTConsole[F[_]: Applicative: Console, E]: Console[EitherT[F, E, *]] =
+    Console[F].mapK[EitherT[F, E, *]](EitherT.liftK)
+
+  implicit def iorTConsole[F[_]: Applicative: Console, L: Semigroup]: Console[IorT[F, L, *]] =
+    Console[F].mapK[IorT[F, L, *]](IorT.liftK)
+
+  implicit def kleisliConsole[F[_]: Applicative: Console, E]: Console[Kleisli[F, E, *]] =
+    Console[F].mapK[Kleisli[F, E, *]](Kleisli.liftK)
+
+  implicit def optionTConsole[F[_]: Applicative: Console, E]: Console[OptionT[F, *]] =
+    Console[F].mapK[OptionT[F, *]](OptionT.liftK)
+
+  implicit def catsReaderWriteStateTSync[F[_]: Applicative: Console, E, L: Monoid, S]
+    : Console[ReaderWriterStateT[F, E, L, S, *]] =
+    Console[F].mapK[ReaderWriterStateT[F, E, L, S, *]](ReaderWriterStateT.liftK)
+
+  implicit def stateTConsole[F[_]: Applicative: Console, S]: Console[StateT[F, S, *]] =
+    Console[F].mapK[StateT[F, S, *]](StateT.liftK)
+
+  implicit def writerTConsole[F[_]: Applicative: Console, L: Monoid]: Console[WriterT[F, L, *]] =
+    Console[F].mapK[WriterT[F, L, *]](WriterT.liftK)
+
 }

--- a/core/src/main/scala/cats/effect/Console.scala
+++ b/core/src/main/scala/cats/effect/Console.scala
@@ -94,7 +94,7 @@ object Console {
   implicit def optionTConsole[F[_]: Applicative: Console, E]: Console[OptionT[F, *]] =
     Console[F].mapK[OptionT[F, *]](OptionT.liftK)
 
-  implicit def catsReaderWriteStateTSync[F[_]: Applicative: Console, E, L: Monoid, S]
+  implicit def readerWriteStateTConsole[F[_]: Applicative: Console, E, L: Monoid, S]
     : Console[ReaderWriterStateT[F, E, L, S, *]] =
     Console[F].mapK[ReaderWriterStateT[F, E, L, S, *]](ReaderWriterStateT.liftK)
 

--- a/core/src/test/scala/cats/effect/ConsoleSpec.scala
+++ b/core/src/test/scala/cats/effect/ConsoleSpec.scala
@@ -101,6 +101,7 @@ class ConsoleSpec extends AnyFunSuite {
     Console[EitherT[F, String, *]]
     Console[IorT[F, String, *]]
     Console[Kleisli[F, String, *]]
+    Console[ReaderWriterStateT[F, String, Int, Boolean, *]]
     Console[StateT[F, Int, *]]
     Console[WriterT[F, String, *]]
   }

--- a/core/src/test/scala/cats/effect/ConsoleSpec.scala
+++ b/core/src/test/scala/cats/effect/ConsoleSpec.scala
@@ -16,15 +16,11 @@
 
 package cats.effect
 
-import cats.data.{ Chain, EitherT }
+import cats._
+import cats.data._
 import cats.effect.concurrent.Ref
-import cats.instances.boolean._
-import cats.instances.double._
-import cats.instances.int._
-import cats.instances.string._
-import cats.syntax.all._
-import cats.FlatMap
 import cats.effect.test.TestConsole
+import cats.implicits._
 import org.scalatest.funsuite.AnyFunSuite
 
 class ConsoleSpec extends AnyFunSuite {
@@ -96,6 +92,17 @@ class ConsoleSpec extends AnyFunSuite {
       }
 
     test.unsafeRunSync()
+  }
+
+  // Monad Transformer instances
+
+  def instances[F[_]: Applicative: Console] = {
+    Console[OptionT[F, *]]
+    Console[EitherT[F, String, *]]
+    Console[IorT[F, String, *]]
+    Console[Kleisli[F, String, *]]
+    Console[StateT[F, Int, *]]
+    Console[WriterT[F, String, *]]
   }
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,9 +3,10 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val catsEffect = "2.0.0"
-    val scalaTest  = "3.1.0"
-    val bm4        = "0.3.0"
+    val catsEffect    = "2.0.0"
+    val scalaTest     = "3.1.0"
+    val bm4           = "0.3.0"
+    val kindProjector = "0.10.3"
   }
 
   object Libraries {
@@ -14,7 +15,8 @@ object Dependencies {
   }
 
   object CompilerPlugins {
-    val bm4 = compilerPlugin("com.olegpy" %% "better-monadic-for" % Versions.bm4)
+    val bm4           = compilerPlugin("com.olegpy"    %% "better-monadic-for" % Versions.bm4)
+    val kindProjector = compilerPlugin("org.typelevel" %% "kind-projector"     % Versions.kindProjector)
   }
 
 }


### PR DESCRIPTION
I was working on some examples using `Console` and Monad Transformers and I figured it makes sense to provide default instances, given some `F[_]: Applicative: Console]`.